### PR TITLE
Prevent NRE when player dies to mechanic

### DIFF
--- a/code/Systems/Player/Controller/PlayerController.cs
+++ b/code/Systems/Player/Controller/PlayerController.cs
@@ -98,6 +98,11 @@ public partial class PlayerController : EntityComponent<Player>, ISingletonCompo
 		foreach ( var mechanic in Mechanics )
 		{
 			mechanic.TrySimulate( this );
+
+			if ( Player == null )
+			{
+				return;
+			}
 		}
 
 		var target = EyeHeight;


### PR DESCRIPTION
If a player dies while a mechanic is being simulated then OnKilled can get called before the rest of the mechanics are simulated

This just makes sure the player isn't null after each mechanic is simulated